### PR TITLE
Add support of underscore character for markdown parsing

### DIFF
--- a/src/parser/operator.rs
+++ b/src/parser/operator.rs
@@ -41,10 +41,14 @@ pub mod bytes {
 }
 
 pub mod pattern {
-    // TextOperator -> ~~
-    pub const BOLD: &str = "**";
+    // TextOperator -> **
+    pub const BOLD_STAR: &str = "**";
+    // TextOperator -> __
+    pub const BOLD_UNDER: &str = "__";
     // TextOperator -> *
-    pub const ITALIC: &str = "*";
+    pub const ITALIC_STAR: &str = "*";
+    // TextOeprator -> _
+    pub const ITALIC_UN: &str = "_";
     // TextOperator -> ~~
     pub const STRIKE: &str = "~~";
     // CODE_PATTERN -> `

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -194,8 +194,8 @@ mod textual {
     #[test]
     fn parse_text_style() {
         let content = "
-            This is a ~~strike~~ *text* lol 
-            ha **End** ha
+            This is a ~~strike~~ **loul** *text* _ha_ lol 
+            ha **End** ha __ho__
         ";
 
         let res = token::get_textual_tokens(content).unwrap();
@@ -220,7 +220,10 @@ mod textual {
             .unwrap();
 
         assert_eq!(italic_vec[0].word, "text");
-        assert_eq!(italic_vec[0].col.unwrap(), 21);
+        assert_eq!(italic_vec[0].col.unwrap(), 30);
+
+        assert_eq!(italic_vec[1].word, "ha");
+        assert_eq!(italic_vec[1].col.unwrap(), 37);
 
         let second_line = res.get(&2).unwrap().text.as_ref().unwrap();
 
@@ -234,6 +237,9 @@ mod textual {
 
         assert_eq!(bold_vec[0].word, "End");
         assert_eq!(bold_vec[0].col.unwrap(), 3);
+
+        assert_eq!(bold_vec[1].word, "ho");
+        assert_eq!(bold_vec[1].col.unwrap(), 14);
     }
 
     #[test]


### PR DESCRIPTION
- Add support of parsing __<words>__ as bold
- Add support of parsing _<word>_ as italic
- Fix unwrap() on None issue when retrieving a character from the regex result
- Adding test case for underscore